### PR TITLE
Add Linters

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: lint
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: set up python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+
+    - name: install Python dependencies
+      run: |
+        pip install -r requirements.txt
+        pip install bandit flake8
+
+    - name: run flake8
+      run: flake8
+
+    - name: run bandit
+      run: bandit -r deterrerscli


### PR DESCRIPTION
This patch adds `flake8` and `bandit` as basic linters to the projects and integrates them via GitHub Actions.