### PR TITLE
Document Shell Completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,26 @@ Options:
 # Activate firewall profile
 ❯ deterrers-cli action register 192.0.0.1
 ```
+
+
+## Shell Completion
+
+The `deterrers-cli` command line tool supports shell completion for several major shells:
+
+For **Bash**, add to `~/.bashrc`:
+
+```
+eval "$(_DETERRERS_CLI_COMPLETE=bash_source deterrers-cli)"
+```
+
+For **ZSH**, add to `~/.zshrc`:
+
+```
+eval "$(_DETERRERS_CLI_COMPLETE=zsh_source deterrers-cli)"
+```
+
+For **fish**, add to `~/.config/fish/completions/deterrers-cli.fish`:
+
+```
+_DETERRERS_CLI_COMPLETE=fish_source deterrers-cli | source
+```


### PR DESCRIPTION
Using the click library allows us to easily add shell completion for `deterrers-cli` to most of the popular shells. This patch documents how to configure completion in those shells.