### PR TITLE
Switch to pyproject.toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include LICENSE README.md requirements.txt
+include LICENSE README.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ['setuptools >= 61.0']
+build-backend = 'setuptools.build_meta'
+
+[project]
+name = 'deterrers-cli'
+version = '0.6'
+authors = [
+    {name = 'Lars Kiesow', email = 'lkiesow@uos.de'}
+]
+description = 'Command line client for DETERRERS'
+readme = {file = 'README.md', content-type = 'text/markdown'}
+requires-python = ">=3.10"
+license = {text = 'MIT'}
+dependencies = [
+    'deterrers-api>=0.4',
+    'PyYAML',
+    'Click'
+]
+
+[project.urls]
+Homepage = 'https://github.com/virtUOS/deterrers-cli'
+Repository = 'https://github.com/virtUOS/deterrers-cli'
+
+[project.scripts]
+deterrers-cli = 'deterrerscli.__main__:cli'

--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,3 @@
 from setuptools import setup
-import os
 
-
-def read(filename):
-    path = os.path.abspath(os.path.dirname(__file__))
-    with open(os.path.join(path, filename), encoding='utf-8') as f:
-        return f.read()
-
-
-setup(
-    name='deterrers-cli',
-    version='0.6',
-    description='Command line client for DETERRERS',
-    url='https://github.com/virtUOS/proteuscmd',
-    author='Lars Kiesow',
-    author_email='lkiesow@uos.de',
-    license='MIT',
-    packages=['deterrerscli'],
-    license_files=('LICENSE'),
-    include_package_data=True,
-    install_requires=read('requirements.txt').split(),
-    long_description=read('README.md'),
-    long_description_content_type='text/markdown',
-    entry_points={
-        'console_scripts': ['deterrers-cli = deterrerscli.__main__:cli'],
-    })
+setup()


### PR DESCRIPTION
This patch makes the project switch from the legacy specification of metadata in the `setup.py` to them being specified in a `pyproject.toml` file.