### PR TITLE
Allow users to skip initial scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ token: <api-token>
 # If you want to automatically register newly added hosts
 # Default: false
 auto-register: false
+
+# If you want to skip the initial security scan by default.
+# Default: false
+auto-skip-scan: false
 ```
 
 ## Usane


### PR DESCRIPTION
This patch allows users to skip the initial security scan when registering hosts with the perimeter firewall.