### PR TITLE
Require API Version 0.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = {file = 'README.md', content-type = 'text/markdown'}
 requires-python = ">=3.10"
 license = {text = 'MIT'}
 dependencies = [
-    'deterrers-api>=0.4',
+    'deterrers-api>=0.5',
     'PyYAML',
     'Click'
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-deterrers-api>=0.4
+deterrers-api>=0.5
 PyYAML
 Click


### PR DESCRIPTION
This patch requires deterrers-api version 0.5 in order to actually support skipping initial security scans.