### PR TITLE
Always honor --no-register

### DIFF
--- a/deterrerscli/__main__.py
+++ b/deterrerscli/__main__.py
@@ -62,7 +62,7 @@ def delete(ipv4):
 @click.option('--admin', '-a', multiple=True, required=True)
 @click.option('--profile', '-p', default='', type=types.PROFILE_TYPE)
 @click.option('--firewall', '-f', default='', type=types.HOST_FIREWALL_TYPE)
-@click.option('--register/--no-register', default=False,
+@click.option('--register/--no-register', default=None,
               help='If the added host should be registered immediately')
 @click.option('--skip-scan/--no-skip-scan', default=None,
               help='If the added host should get an initial security scan. '
@@ -72,7 +72,7 @@ def add(ipv4, admin, profile, firewall, register, skip_scan):
     '''Add IP address to DETERRERS.
     '''
     deterrers.add(ipv4, admin, profile, firewall)
-    if profile and auto_register or register:
+    if profile and (auto_register if register is None else register):
         skip_scan = auto_skip_scan if skip_scan is None else skip_scan
         deterrers.action(ipv4, 'register', skip_scan)
 


### PR DESCRIPTION
If `auto-register` was turned on, newly added hosts would always be registered automatically. Even if the `--no-register` was specifically set as command line parameter. The cli parameters should always overwrite the defaults set in the configuration. That's what this patch is fixing.